### PR TITLE
Fix: importClassesFromDirectories module import

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,7 +12,7 @@ export function importClassesFromDirectories(directories: string[], formats = ['
     } else if (exported instanceof Array) {
       exported.forEach((i: any) => loadFileClasses(i, allLoaded));
     } else if (exported instanceof Object || typeof exported === 'object') {
-      Object.keys(exported).forEach(key => loadFileClasses(exported[key], allLoaded));
+      for (const key in exported) loadFileClasses(exported[key], allLoaded);
     }
 
     return allLoaded;


### PR DESCRIPTION
The current `importClassesFromDirectories` implementation uses `Object#keys` to loop over module exports, which seems to break the demo.

This PR changes the module loop to use `for (key in obj)` instead, which fixes the bug.

## How to replicate the bug:
Run the demo by using
```
bun demo/index.ts
```
then navigate to http://localhost:3000/

```
Bun version: 1.1.8
```