### PR TITLE
Add support for optional segments

### DIFF
--- a/src/ControllerManager.ts
+++ b/src/ControllerManager.ts
@@ -14,10 +14,22 @@ export class ControllerManager {
             const prefix = Reflect.getMetadata('prefix', controller);
             const routes: Array<ElysiaRoute> = Reflect.getMetadata('routes', controller);
             routes.forEach((route) => {
-                if (route.method === "WS") {
-                    return app.ws(`${prefix}${route.path}`, { ...route.options, message: (ctx: any) => Promise.resolve(instance[route.methodName](ctx))} as any);
-                  }
-                return app.route(route.method, `${prefix}${route.path}`, (ctx: any) => Promise.resolve(instance[route.methodName](ctx)), route.options);
+                const segments = route.path.split('/');
+
+                route.path = '';
+                for (let i = 1; i < segments.length; i++) {
+                    route.path += `/${segments[i]!.replace(/\?$/, '')}`;
+
+                    // Make route for current path if next segment does not exist or is optional
+                    const needRouting = segments[i + 1]?.endsWith('?') ?? true;
+                    if (!needRouting) continue;
+
+                    if (route.method === "WS") {
+                        app.ws(`${prefix}${route.path}`, { ...route.options, message: (ctx: any) => Promise.resolve(instance[route.methodName](ctx)) } as any);
+                        continue;
+                    }
+                    app.route(route.method, `${prefix}${route.path}`, (ctx: any) => Promise.resolve(instance[route.methodName](ctx)), route.options);
+                }
             })
         }
         return app;


### PR DESCRIPTION
Added support for paths with optional segments.

For example, `@Get('/api/:module?/:version?')` will register 3 routes:

>/api
>/api/:module
>/api/:module/:version